### PR TITLE
Fix for JAFFA in WSL

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -199,7 +199,6 @@
                 },
                 "jaffal_dir": {
                     "type": "string",
-                    "format": "directory-path",
                     "description": "Path to the JAFFAL code directory. If running within EPI2ME-Labs, the default path of /home/epi2melabs/JAFFA within the application container will be used. If using outside of EPI2ME-Labs, the path to the code directory downloaded from github should be supplied.",
                     "default": "/home/epi2melabs/JAFFA",
                     "hidden": true


### PR DESCRIPTION
When running the workflow from EPI2ME Desktop on Windows, I encountered an error while running the JAFFAL step:

```
ERROR ~ Error executing process > 'pipeline:gene_fusions:jaffal (1)'
Caused by:
  Missing output file(s) `jaffal_output_human` expected by process `pipeline:gene_fusions:jaffal (1)`
Command executed:
  JAFFAOUT=jaffal_output_human
  
  # JAFFAL exists with status code 1 when there's 0 fusion hits. Prevent this with '||:'
  /mnt/c/home/epi2melabs/JAFFA/tools/bin/bpipe run         -n 48         -p jaffa_output="$JAFFAOUT/"         -p refBase=JAFFA_REFERENCE_FILES_HG38_GENCODE22.V2         -p genome=hg38         -p annotation=genCode22         -p fastqInputFormat="*.fastq"         /mnt/c/home/epi2melabs/JAFFA/JAFFAL.groovy         human_full_length_reads.fastq || :
  
  summary="$JAFFAOUT/all/all.summary"
  
  if [ -f $summary ]; then
      # The summary is writtten so assume JAFFAL completed.
      if [ ! -s $summary ]; then
          echo "JAFFAL failed to find any fusion transcripts for human"
          touch "$JAFFAOUT/human_jaffa_results.csv"
      else
          echo JAFFAL found fusion transcripts for human
          mv "$JAFFAOUT/jaffa_results.csv" "$JAFFAOUT/human_jaffa_results.csv"
          # Add sample id column and header
          sed "s/$/,human/" $JAFFAOUT/human_jaffa_results.csv                 | sed "1 s/human/sample_id/" > tmp
          mv tmp $JAFFAOUT/human_jaffa_results.csv
      fi
  else
      echo JAFFAL encountered an error while prosessing human
  fi
Command exit status:
  0
Command output:
  JAFFAL encountered an error while prosessing human
Command error:
  .command.sh: line 5: /mnt/c/home/epi2melabs/JAFFA/tools/bin/bpipe: No such file or directory
Work dir:
  /mnt/c/Users/gandallab/epi2melabs/instances/wf-transcriptomes_01HG90SZKKQHWZM4REXK1CAMH2/work/06/dd690042877dc2e482f445dd683689
Tip: when you have fixed the problem you can continue the execution adding the option `-resume` to the run command line
 -- Check '/mnt/c/Users/gandallab/epi2melabs/instances/wf-transcriptomes_01HG90SZKKQHWZM4REXK1CAMH2/nextflow.log' file for details
WARN: Killing running tasks (1)
```

It seems that there is a hidden setting for the path to the JAFFA directory. It's default value, `/home/epi2melabs/JAFFA`, is relative to the container environment and should remain unchanged. However, on Windows the default value is getting validated and changed to a path relative to WSL, `/mnt/c/home/epi2melabs/JAFFA`.

![Screenshot 2023-11-29 112723](https://github.com/epi2me-labs/wf-transcriptomes/assets/108516/159a814d-3c46-4925-9460-c45d5dd831f0)

Although the EPI2ME application provides a textbox for additional Nextflow configuration with `-c`, the `jaffal_dir` parameter cannot be overridden here because the configuration generated by the application is provided to Nextflow via `-params-file` and takes precedence.

I was able to fix this issue and run the workflow to completion by modifying the Nextflow schema JSON to simply specify the `jaffal_dir` parameter as a `string` type with no `format` setting.

![Screenshot 2023-11-29 124411](https://github.com/epi2me-labs/wf-transcriptomes/assets/108516/b66fbf4e-17c3-48eb-8378-e725c4d642d0)

Note that the `jaffal_dir` parameter no longer appears in the log because it's value doesn't differ from the default.
