### PR TITLE
fix typos in tests.sh

### DIFF
--- a/evaluation/tests.sh
+++ b/evaluation/tests.sh
@@ -36,7 +36,7 @@ results+=("$(basename $OUTPUT): $r")
 OUTPUT=$1/multiple_samples;
 nextflow run . --fastq $multisampledir $config --ref_genome test_data/SIRV_150601a.fasta --minimap2_opts '-uf --splice-flank=no'\
 --ref_annotation test_data/SIRV_isoforms.gtf -profile local --out_dir ${OUTPUT} -w ${OUTPUT}/workspace \
---sample_sheet test_data/sample_sheet -resume;
+--sample_sheet test_data/sample_sheet.csv -resume;
 r=$?
 results+=("$(basename $OUTPUT): $r")
 

--- a/evaluation/tests.sh
+++ b/evaluation/tests.sh
@@ -29,13 +29,13 @@ results=()
 # Reference based tests
 OUTPUT=$1/reference_single_dir;
 nextflow run . --fastq $singledir $config --ref_genome test_data/SIRV_150601a.fasta --minimap2_opts '-uf --splice-flank=no' \
---ref_annotation test_data/SIRV_isofroms.gtf -profile local --out_dir ${OUTPUT} -w ${OUTPUT}/workspace -resume;
+--ref_annotation test_data/SIRV_isoforms.gtf -profile local --out_dir ${OUTPUT} -w ${OUTPUT}/workspace -resume;
 r=$?
 results+=("$(basename $OUTPUT): $r")
 
 OUTPUT=$1/multiple_samples;
 nextflow run . --fastq $multisampledir $config --ref_genome test_data/SIRV_150601a.fasta --minimap2_opts '-uf --splice-flank=no'\
---ref_annotation test_data/SIRV_isofroms.gtf -profile local --out_dir ${OUTPUT} -w ${OUTPUT}/workspace \
+--ref_annotation test_data/SIRV_isoforms.gtf -profile local --out_dir ${OUTPUT} -w ${OUTPUT}/workspace \
 --sample_sheet test_data/sample_sheet -resume;
 r=$?
 results+=("$(basename $OUTPUT): $r")
@@ -49,7 +49,7 @@ results+=("$(basename $OUTPUT): $r")
 # Force split_bam to make multiple alignment bundles
 OUTPUT=$1/reference_frce_split_bam;
 nextflow run . --fastq $singledir  $config --ref_genome test_data/SIRV_150601a.fasta --minimap2_opts '-uf --splice-flank=no'\
---ref_annotation test_data/SIRV_isofroms.gtf -profile local --out_dir ${OUTPUT} -w ${OUTPUT}/workspace \
+--ref_annotation test_data/SIRV_isoforms.gtf -profile local --out_dir ${OUTPUT} -w ${OUTPUT}/workspace \
 --bundle_min_reads 5 -resume;
 r=$?
 results+=("$(basename $OUTPUT): $r")

--- a/test_data/sample_sheet.csv
+++ b/test_data/sample_sheet.csv
@@ -1,7 +1,3 @@
 barcode,sample_id,alias,condition
 barcode01,sample01,sample01,control
 barcode02,sample02,sample02,control
-barcode03,sample03,sample03,control
-barcode04,sample04,sample04,treated
-barcode05,sample05,sample05,treated
-barcode06,sample06,sample06,treated


### PR DESCRIPTION
1. there are a few typos on filenames.
2. test sample_sheet has entries that does not exist in test_dir

In other notes, I have more success using profile = standard, rather than profile = local